### PR TITLE
base: silent mode is back

### DIFF
--- a/media/java/android/media/AudioManagerInternal.java
+++ b/media/java/android/media/AudioManagerInternal.java
@@ -56,6 +56,10 @@ public abstract class AudioManagerInternal {
 
         boolean canVolumeDownEnterSilent();
 
+        boolean canVolumeUpExitSilent();
+
+        void onVolumeDownInSilent(VolumePolicy policy);
+
         int getRingerModeAffectedStreams(int streams);
     }
 }

--- a/media/java/android/media/VolumePolicy.java
+++ b/media/java/android/media/VolumePolicy.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 
 /** @hide */
 public final class VolumePolicy implements Parcelable {
-    public static final VolumePolicy DEFAULT = new VolumePolicy(false, false, true, 400);
+    public static final VolumePolicy DEFAULT = new VolumePolicy(false, false, true, 400, false);
 
     /** Allow volume adjustments lower from vibrate to enter ringer mode = silent */
     public final boolean volumeDownToEnterSilent;
@@ -38,12 +38,16 @@ public final class VolumePolicy implements Parcelable {
         number of milliseconds since an adjustment from normal to vibrate. */
     public final int vibrateToSilentDebounce;
 
+    /** Automatically enter do not disturb when ringer mode = silent and pressing volume down */
+    public final boolean doNotDisturbWhenVolumeDownInSilent;
+
     public VolumePolicy(boolean volumeDownToEnterSilent, boolean volumeUpToExitSilent,
-            boolean doNotDisturbWhenSilent, int vibrateToSilentDebounce) {
+            boolean doNotDisturbWhenSilent, int vibrateToSilentDebounce, boolean doNotDisturbWhenVolumeDownInSilent) {
         this.volumeDownToEnterSilent = volumeDownToEnterSilent;
         this.volumeUpToExitSilent = volumeUpToExitSilent;
         this.doNotDisturbWhenSilent = doNotDisturbWhenSilent;
         this.vibrateToSilentDebounce = vibrateToSilentDebounce;
+        this.doNotDisturbWhenVolumeDownInSilent = doNotDisturbWhenVolumeDownInSilent;
     }
 
     @Override
@@ -51,13 +55,14 @@ public final class VolumePolicy implements Parcelable {
         return "VolumePolicy[volumeDownToEnterSilent=" + volumeDownToEnterSilent
                 + ",volumeUpToExitSilent=" + volumeUpToExitSilent
                 + ",doNotDisturbWhenSilent=" + doNotDisturbWhenSilent
-                + ",vibrateToSilentDebounce=" + vibrateToSilentDebounce + "]";
+                + ",vibrateToSilentDebounce=" + vibrateToSilentDebounce
+                + ",doNotDisturbWhenVolumeDownInSilent=" + doNotDisturbWhenVolumeDownInSilent + "]";
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(volumeDownToEnterSilent, volumeUpToExitSilent, doNotDisturbWhenSilent,
-                vibrateToSilentDebounce);
+                vibrateToSilentDebounce, doNotDisturbWhenVolumeDownInSilent);
     }
 
     @Override
@@ -68,7 +73,8 @@ public final class VolumePolicy implements Parcelable {
         return other.volumeDownToEnterSilent == volumeDownToEnterSilent
                 && other.volumeUpToExitSilent == volumeUpToExitSilent
                 && other.doNotDisturbWhenSilent == doNotDisturbWhenSilent
-                && other.vibrateToSilentDebounce == vibrateToSilentDebounce;
+                && other.vibrateToSilentDebounce == vibrateToSilentDebounce
+                && other.doNotDisturbWhenVolumeDownInSilent == doNotDisturbWhenVolumeDownInSilent;
     }
 
     @Override
@@ -82,6 +88,7 @@ public final class VolumePolicy implements Parcelable {
         dest.writeInt(volumeUpToExitSilent ? 1 : 0);
         dest.writeInt(doNotDisturbWhenSilent ? 1 : 0);
         dest.writeInt(vibrateToSilentDebounce);
+        dest.writeInt(doNotDisturbWhenVolumeDownInSilent ? 1 : 0);
     }
 
     public static final Parcelable.Creator<VolumePolicy> CREATOR
@@ -91,7 +98,8 @@ public final class VolumePolicy implements Parcelable {
             return new VolumePolicy(p.readInt() != 0,
                     p.readInt() != 0,
                     p.readInt() != 0,
-                    p.readInt());
+                    p.readInt(),
+                    p.readInt() != 0);
         }
 
         @Override

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarPolicy.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarPolicy.java
@@ -331,11 +331,16 @@ public class PhoneStatusBarPolicy implements Callback, RotationLockController.Ro
             volumeVisible = true;
             volumeIconId = R.drawable.stat_sys_ringer_silent;
             volumeDescription = mContext.getString(R.string.accessibility_ringer_silent);
-        } else if (mZen != Global.ZEN_MODE_NO_INTERRUPTIONS && mZen != Global.ZEN_MODE_ALARMS &&
-                audioManager.getRingerModeInternal() == AudioManager.RINGER_MODE_VIBRATE) {
-            volumeVisible = true;
-            volumeIconId = R.drawable.stat_sys_ringer_vibrate;
-            volumeDescription = mContext.getString(R.string.accessibility_ringer_vibrate);
+        } else if (mZen != Global.ZEN_MODE_NO_INTERRUPTIONS && mZen != Global.ZEN_MODE_ALARMS) {
+            if (audioManager.getRingerModeInternal() == AudioManager.RINGER_MODE_VIBRATE) {
+                volumeVisible = true;
+                volumeIconId = R.drawable.stat_sys_ringer_vibrate;
+                volumeDescription = mContext.getString(R.string.accessibility_ringer_vibrate);
+            } else if(audioManager.getRingerModeInternal() == AudioManager.RINGER_MODE_SILENT) {
+                volumeVisible = true;
+                volumeIconId = R.drawable.stat_sys_ringer_silent;
+                volumeDescription = mContext.getString(R.string.accessibility_ringer_silent);
+            }
         }
 
         if (zenVisible) {

--- a/packages/SystemUI/src/com/android/systemui/volume/VolumeDialog.java
+++ b/packages/SystemUI/src/com/android/systemui/volume/VolumeDialog.java
@@ -436,13 +436,16 @@ public class VolumeDialog implements TunerService.Tunable {
                         if (hasVibrator) {
                             mController.setRingerMode(AudioManager.RINGER_MODE_VIBRATE, false);
                         } else {
-                            final boolean wasZero = row.ss.level == 0;
-                            mController.setStreamVolume(stream, wasZero ? row.lastAudibleLevel : 0);
+                           mController.setRingerMode(AudioManager.RINGER_MODE_SILENT, false);
                         }
+                    } else if (mState.ringerModeInternal == AudioManager.RINGER_MODE_VIBRATE) {
+                       mController.setRingerMode(AudioManager.RINGER_MODE_SILENT, false);
                     } else {
                         mController.setRingerMode(AudioManager.RINGER_MODE_NORMAL, false);
                         if (row.ss.level == 0) {
                             mController.setStreamVolume(stream, 1);
+                        } else {
+                            mController.setStreamVolume(stream, row.lastAudibleLevel); 
                         }
                     }
                 } else if (row.stream == AudioManager.STREAM_NOTIFICATION) {
@@ -794,7 +797,8 @@ public class VolumeDialog implements TunerService.Tunable {
         row.icon.setAlpha(iconEnabled ? 1 : 0.5f);
         final int iconRes =
                 isRingVibrate ? R.drawable.ic_volume_ringer_vibrate
-                : zenMuted ? row.cachedIconRes
+		: isRingSilent ? R.drawable.ic_volume_ringer_mute
+		: zenMuted ? row.cachedIconRes
                 : ss.routedToBluetooth ?
                         (ss.muted ? R.drawable.ic_volume_media_bt_mute
                                 : R.drawable.ic_volume_media_bt)

--- a/packages/SystemUI/src/com/android/systemui/volume/VolumeDialogComponent.java
+++ b/packages/SystemUI/src/com/android/systemui/volume/VolumeDialogComponent.java
@@ -47,7 +47,7 @@ public class VolumeDialogComponent implements VolumeComponent, TunerService.Tuna
 
     public static final boolean DEFAULT_VOLUME_DOWN_TO_ENTER_SILENT = true;
     public static final boolean DEFAULT_VOLUME_UP_TO_EXIT_SILENT = true;
-    public static final boolean DEFAULT_DO_NOT_DISTURB_WHEN_SILENT = true;
+    public static final boolean DEFAULT_DO_NOT_DISTURB_WHEN_SILENT = false;
 
     private final SystemUI mSysui;
     private final Context mContext;
@@ -58,7 +58,8 @@ public class VolumeDialogComponent implements VolumeComponent, TunerService.Tuna
             DEFAULT_VOLUME_DOWN_TO_ENTER_SILENT,  // volumeDownToEnterSilent
             DEFAULT_VOLUME_UP_TO_EXIT_SILENT,  // volumeUpToExitSilent
             DEFAULT_DO_NOT_DISTURB_WHEN_SILENT,  // doNotDisturbWhenSilent
-            400    // vibrateToSilentDebounce
+            400,    // vibrateToSilentDebounce
+            true    // doNotDisturbWhenVolumeDownInSilent
     );
 
     public VolumeDialogComponent(SystemUI sysui, Context context, Handler handler,
@@ -87,28 +88,28 @@ public class VolumeDialogComponent implements VolumeComponent, TunerService.Tuna
                     : DEFAULT_VOLUME_DOWN_TO_ENTER_SILENT;
             setVolumePolicy(volumeDownToEnterSilent,
                     mVolumePolicy.volumeUpToExitSilent, mVolumePolicy.doNotDisturbWhenSilent,
-                    mVolumePolicy.vibrateToSilentDebounce);
+                    mVolumePolicy.vibrateToSilentDebounce, mVolumePolicy.doNotDisturbWhenVolumeDownInSilent);
         } else if (VOLUME_UP_SILENT.equals(key)) {
             final boolean volumeUpToExitSilent = newValue != null
                     ? Integer.parseInt(newValue) != 0
                     : DEFAULT_VOLUME_UP_TO_EXIT_SILENT;
             setVolumePolicy(mVolumePolicy.volumeDownToEnterSilent,
                     volumeUpToExitSilent, mVolumePolicy.doNotDisturbWhenSilent,
-                    mVolumePolicy.vibrateToSilentDebounce);
+                    mVolumePolicy.vibrateToSilentDebounce, mVolumePolicy.doNotDisturbWhenVolumeDownInSilent);
         } else if (VOLUME_SILENT_DO_NOT_DISTURB.equals(key)) {
             final boolean doNotDisturbWhenSilent = newValue != null
                     ? Integer.parseInt(newValue) != 0
                     : DEFAULT_DO_NOT_DISTURB_WHEN_SILENT;
             setVolumePolicy(mVolumePolicy.volumeDownToEnterSilent,
                     mVolumePolicy.volumeUpToExitSilent, doNotDisturbWhenSilent,
-                    mVolumePolicy.vibrateToSilentDebounce);
+                    mVolumePolicy.vibrateToSilentDebounce, mVolumePolicy.doNotDisturbWhenVolumeDownInSilent);
         }
     }
 
     private void setVolumePolicy(boolean volumeDownToEnterSilent, boolean volumeUpToExitSilent,
-            boolean doNotDisturbWhenSilent, int vibrateToSilentDebounce) {
+            boolean doNotDisturbWhenSilent, int vibrateToSilentDebounce, boolean doNotDisturbWhenVolumeDownInSilent) {
         mVolumePolicy = new VolumePolicy(volumeDownToEnterSilent, volumeUpToExitSilent,
-                doNotDisturbWhenSilent, vibrateToSilentDebounce);
+                doNotDisturbWhenSilent, vibrateToSilentDebounce, doNotDisturbWhenVolumeDownInSilent);
         mController.setVolumePolicy(mVolumePolicy);
     }
 

--- a/services/core/java/com/android/server/audio/AudioService.java
+++ b/services/core/java/com/android/server/audio/AudioService.java
@@ -3713,17 +3713,15 @@ public class AudioService extends IAudioService.Stub {
             } else if (direction == AudioManager.ADJUST_RAISE
                     || direction == AudioManager.ADJUST_TOGGLE_MUTE
                     || direction == AudioManager.ADJUST_UNMUTE) {
-                if (!mVolumePolicy.volumeUpToExitSilent) {
-                    result |= AudioManager.FLAG_SHOW_SILENT_HINT;
+                if (mVolumePolicy.volumeUpToExitSilent && mRingerModeDelegate.canVolumeUpExitSilent()) {
+                     // go straight back to normal.
+                    ringerMode = RINGER_MODE_NORMAL;
                 } else {
-                  if (mHasVibrator && direction == AudioManager.ADJUST_RAISE) {
-                      ringerMode = RINGER_MODE_VIBRATE;
-                  } else {
-                      // If we don't have a vibrator or they were toggling mute
-                      // go straight back to normal.
-                      ringerMode = RINGER_MODE_NORMAL;
-                  }
+                    result |= AudioManager.FLAG_SHOW_SILENT_HINT;
                 }
+            } else if (direction == AudioManager.ADJUST_LOWER) {
+                // volume down when already in silent
+                mRingerModeDelegate.onVolumeDownInSilent(mVolumePolicy);
             }
             result &= ~FLAG_ADJUST_VOLUME;
             break;

--- a/services/core/java/com/android/server/notification/ZenModeHelper.java
+++ b/services/core/java/com/android/server/notification/ZenModeHelper.java
@@ -962,7 +962,7 @@ public class ZenModeHelper {
                             && (mZenMode == Global.ZEN_MODE_NO_INTERRUPTIONS
                                     || mZenMode == Global.ZEN_MODE_ALARMS)) {
                         newZen = Global.ZEN_MODE_OFF;
-                    } else if (mZenMode != Global.ZEN_MODE_OFF) {
+                    } else if (mZenMode != Global.ZEN_MODE_OFF && mZenMode != Global.ZEN_MODE_IMPORTANT_INTERRUPTIONS) {
                         ringerModeExternalOut = AudioManager.RINGER_MODE_SILENT;
                     }
                     break;
@@ -1019,7 +1019,26 @@ public class ZenModeHelper {
 
         @Override
         public boolean canVolumeDownEnterSilent() {
-            return mZenMode == Global.ZEN_MODE_OFF;
+            return mZenMode == Global.ZEN_MODE_OFF || mZenMode == Global.ZEN_MODE_IMPORTANT_INTERRUPTIONS;
+        }
+
+        @Override
+        public boolean canVolumeUpExitSilent() {
+            return mZenMode == Global.ZEN_MODE_OFF || mZenMode == Global.ZEN_MODE_IMPORTANT_INTERRUPTIONS;
+        }
+
+        @Override
+        public void onVolumeDownInSilent(VolumePolicy policy) {
+            if (policy.doNotDisturbWhenVolumeDownInSilent) {
+                int newZen = -1;
+                if (mZenMode != Global.ZEN_MODE_NO_INTERRUPTIONS
+                        && mZenMode != Global.ZEN_MODE_ALARMS) {
+                    newZen = Global.ZEN_MODE_ALARMS;
+                }
+                if (newZen != -1) {
+                    setManualZenMode(newZen, null, "onVolumeDownInSilent", null, false /*setRingerMode*/);
+                }
+            }
         }
 
         @Override

--- a/services/core/java/com/android/server/policy/GlobalActions.java
+++ b/services/core/java/com/android/server/policy/GlobalActions.java
@@ -1003,7 +1003,7 @@ class GlobalActions implements DialogInterface.OnDismissListener, DialogInterfac
     private void refreshSilentMode() {
         if (!mHasVibrator) {
             final boolean silentModeOn =
-                    mAudioManager.getRingerMode() != AudioManager.RINGER_MODE_NORMAL;
+                    mAudioManager.getRingerModeInternal() != AudioManager.RINGER_MODE_NORMAL;
             ((ToggleAction)mSilentModeAction).updateState(
                     silentModeOn ? ToggleAction.State.On : ToggleAction.State.Off);
         }
@@ -1407,7 +1407,7 @@ class GlobalActions implements DialogInterface.OnDismissListener, DialogInterfac
                 LayoutInflater inflater) {
             View v = inflater.inflate(R.layout.global_actions_silent_mode, parent, false);
 
-            int selectedIndex = ringerModeToIndex(mAudioManager.getRingerMode());
+            int selectedIndex = ringerModeToIndex(mAudioManager.getRingerModeInternal());
             for (int i = 0; i < 3; i++) {
                 View itemView = v.findViewById(ITEM_IDS[i]);
                 itemView.setSelected(selectedIndex == i);
@@ -1440,7 +1440,7 @@ class GlobalActions implements DialogInterface.OnDismissListener, DialogInterfac
             if (!(v.getTag() instanceof Integer)) return;
 
             int index = (Integer) v.getTag();
-            mAudioManager.setRingerMode(indexToRingerMode(index));
+            mAudioManager.setRingerModeInternal(indexToRingerMode(index));
             mHandler.sendEmptyMessageDelayed(MESSAGE_DISMISS, DIALOG_DISMISS_DELAY);
         }
     }


### PR DESCRIPTION
Update SoundTile for silent

ringer mode silent for normal mode and priority interruptions

can be enabled/disabled with
-volume down/up
-pressing icon in volume panel
-global actions menu

Changing ringer mode from silent while in other dnd mode
will stop dnd except via volume up

PS6:
-add volume down in silent enters dnd

Change-Id: I368e0dbf6770feb3ad3c39417a0014bf7f4c5cba
Signed-off-by: mydongistiny <jaysonedson@gmail.com>
Signed-off-by: Rohit Jaiswal <jaiswal.rohit6@gmail.com>

Conflicts:
	core/res/res/values/config.xml