### PR TITLE
fingerprint: handle PerformanceStats NULL pointers

### DIFF
--- a/services/core/java/com/android/server/fingerprint/FingerprintService.java
+++ b/services/core/java/com/android/server/fingerprint/FingerprintService.java
@@ -289,10 +289,12 @@ public class FingerprintService extends SystemService implements IBinder.DeathRe
         if (client != null && client.onAuthenticated(fingerId, groupId)) {
             removeClient(client);
         }
-        if (fingerId != 0) {
-            mPerformanceStats.accept++;
-        } else {
-            mPerformanceStats.reject++;
+        if (mPerformanceStats != null) {
+             if (fingerId != 0) {
+                 mPerformanceStats.accept++;
+             } else {
+                 mPerformanceStats.reject++;
+             }
         }
     }
 
@@ -575,7 +577,7 @@ public class FingerprintService extends SystemService implements IBinder.DeathRe
             @Override
             public boolean handleFailedAttempt() {
                 mFailedAttempts++;
-                if (mFailedAttempts == MAX_FAILED_ATTEMPTS) {
+                if (mPerformanceStats != null && mFailedAttempts == MAX_FAILED_ATTEMPTS) {
                     mPerformanceStats.lockout++;
                 }
                 if (inLockoutMode()) {


### PR DESCRIPTION
fingerprint: handle PerformanceStats NULL pointers
bcc100a has added support for this feature, but the NULL checks
weren't complete, only "handleAcquired" was checking if PerformanceStats
was supported before calling the API.
Extend the NULL checks to "handleAuthenticated" and "handleFailedAttempt"
calls as well.

Change-Id: I3cc9b35ea6b81dc0c503b9feab940873b344323e
Signed-off-by: Ícaro Hoff <icarohoff@gmail.com>
Signed-off-by: Rohit Jaiswal <jaiswal.rohit6@gmail.com>