### PR TITLE
Edit Icon Toggle [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5167,6 +5167,11 @@ public final class Settings {
          */
         public static final String RECENTS_LAYOUT_STYLE = "recents_layout_style";
 
+        /**
+         * Whether to show or hide the edit icon
+         * @hide
+         */
+        public static final String QS_EDIT_TOGGLE = "qs_edit_toggle";
 
         /**
          * Settings to backup. This is here so that it's in the same place as the settings

--- a/packages/SystemUI/src/com/android/systemui/qs/QSFooterImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSFooterImpl.java
@@ -108,6 +108,8 @@ public class QSFooterImpl extends FrameLayout implements QSFooter,
     private boolean mKeyguardShowing;
     private TouchAnimator mAlarmAnimator;
     private boolean hasRunningServices;
+    private boolean hasEdit;
+
 
     public QSFooterImpl(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -322,11 +324,12 @@ public class QSFooterImpl extends FrameLayout implements QSFooter,
         mSettingsContainer.findViewById(R.id.tuner_icon).setVisibility(View.INVISIBLE);
         final boolean isDemo = UserManager.isDeviceInDemoMode(mContext);
         hasRunningServices = !isRunningServicesDisabled();
+        hasEdit = !isEditDisabled();
 
         mMultiUserSwitch.setVisibility(mExpanded && mMultiUserSwitch.hasMultipleUsers() && !isDemo
                 ? View.VISIBLE : View.INVISIBLE);
 
-        mEdit.setVisibility(isDemo || !mExpanded ? View.INVISIBLE : View.VISIBLE);
+        mEdit.setVisibility(hasEdit ?  !isDemo || !mExpanded ? View.INVISIBLE : View.VISIBLE : ViewGONE);
 
         mRunningServicesButton.setVisibility(hasRunningServices ? !isDemo && mExpanded ? View.VISIBLE : View.INVISIBLE : View.GONE);
     }
@@ -358,6 +361,11 @@ public class QSFooterImpl extends FrameLayout implements QSFooter,
     public boolean isRunningServicesDisabled() {
         return Settings.System.getInt(mContext.getContentResolver(),
             Settings.System.QS_RUNNING_SERVICES_TOGGLE, 0) == 1;
+    }
+
+    public boolean isEditDisabled() {
+        return Settings.System.getInt(mContext.getContentResolver(),
+            Settings.System.QS_EDIT_TOGGLE, 0) == 1;
     }
 
     @Override


### PR DESCRIPTION
aex edits(@hamza-badar):- Adapt for oreo

Adds toggle for the quick tiles edit

@nathanchance edit: Switched the logic so that enabling the setting disables the icon so that all switches are disabled by default. Also removed the Settings expanded option.

Signed-off-by: Joe Maples <joe@frap129.org>
Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>